### PR TITLE
Optimize weights

### DIFF
--- a/srcs/logreg_train.py
+++ b/srcs/logreg_train.py
@@ -16,7 +16,7 @@ def harrypotter():
 	df.drop('Hogwarts House', inplace=True, axis=1)
 	x = df.to_numpy()
 
-	lr = LogisticRegression(n_iterations=5000)
+	lr = LogisticRegression(n_iterations=100)
 	train_x, train_y, test_x, test_y = lr.train_test_split(x, y, test_size=0.2)
 	lr.fit(train_x, train_y)
 	test_preds = lr.predict(test_x)

--- a/srcs/pkgs/logisticregression.py
+++ b/srcs/pkgs/logisticregression.py
@@ -67,8 +67,8 @@ class LogisticRegression:
 
 	def initial_weights(self, features, target):
 		feature_amount, target_options = features.shape[1], len(np.unique(target))
-		self.weights = np.random.rand(target_options, feature_amount)
-		self.biases = np.random.rand(target_options, 1)
+		self.weights = np.zeros((target_options, feature_amount))
+		self.biases = np.zeros((target_options, 1))
 
 	def linear_predict(self, feature_matrix):
 		"""This is the linear predictor function for out MLR model. It calculates the logit scores for each possible outcome.

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+pip3 install -r requirements.txt > /dev/null
+
+python3 srcs/logreg_train.py datasets/dataset_train.csv
+python3 srcs/logreg_predict.py datasets/dataset_test.csv datasets/weights
+
+python3 secret/evaluate.py


### PR DESCRIPTION
By setting initial weights to zeros instead of random values, I can predict way more accurately with lower iteration numbers, which makes running it miles faster!

With ~5000 iterations, my predictions score stay roughly the same, but the difference is very noticeable the lower my iterations go.
Right now my scores jumped up from ~90% to 98.5%. Right now that means that amount of iterations above 200 is practically meaningless.